### PR TITLE
Merge JCA and BC-JCA rules

### DIFF
--- a/sonar-crypto-plugin/src/main/java/org/sonarcrypto/CryptoSensor.java
+++ b/sonar-crypto-plugin/src/main/java/org/sonarcrypto/CryptoSensor.java
@@ -44,7 +44,7 @@ public class CryptoSensor implements Sensor {
   }
 
   protected RulesetPaths extractRules() throws IOException {
-    final Ruleset ruleset = Ruleset.JCA;
+    final Ruleset ruleset = Ruleset.JCA_BC_JCA;
     try {
       return new CryslRuleProvider().extractRulesetToTempDir(ruleset);
     } catch (IOException | URISyntaxException e) {

--- a/utils/cognicrypt/src/main/java/org/sonarcrypto/utils/cognicrypt/crysl/Ruleset.java
+++ b/utils/cognicrypt/src/main/java/org/sonarcrypto/utils/cognicrypt/crysl/Ruleset.java
@@ -5,16 +5,19 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public enum Ruleset {
 
-  /** Bouncy Castle */
+  /** Bouncy Castle with its own API */
   BC("bc"),
 
-  /** Bouncy Castle and JCA */
+  /** Bouncy Castle for JCA */
   BC_JCA("bc-jca"),
 
   /** JCA */
   JCA("jca"),
 
-  /** Google Tink */
+  /** JCA with Bouncy Castle for JCA */
+  JCA_BC_JCA("jca-bc-jca"),
+
+  /** Google Tink with its own API */
   TINK("tink");
 
   private final String rulesetName;


### PR DESCRIPTION
I've merged the JCA and the BC-JCA rules enabling to analyze for both providers. The merged ruleset was committed to the [master branch o four Crypto-API-Rules fork ](https://github.com/SonarCryptography/Crypto-API-Rules/commit/c946670c5d7bff23d8c5bdd9706bf14a29283646).