### PR TITLE
Store submodule hashes in .deps-installed to auto-detect staleness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,16 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
+      - name: Compute submodule hashes for cache key
+        shell: bash
+        run: git submodule status --cached > .submodule-hashes
       - name: Cache Maven packages
         uses: actions/cache@v6
         with:
           path: |
             ~/.m2
             external/.deps-installed
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ hashFiles('.submodule-hashes') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build & Test (No E2E) & Analyze
         env:
@@ -73,13 +76,16 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Compute submodule hashes for cache key
+        shell: bash
+        run: git submodule status --cached > .submodule-hashes
       - name: Cache Maven packages
         uses: actions/cache@v6
         with:
           path: |
             ~/.m2
             external/.deps-installed
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ hashFiles('.submodule-hashes') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build & Test (No E2E) & Analyze
         env:
@@ -102,13 +108,16 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Compute submodule hashes for cache key
+        shell: bash
+        run: git submodule status --cached > .submodule-hashes
       - name: Cache Maven packages
         uses: actions/cache@v6
         with:
           path: |
             ~/.m2
             external/.deps-installed
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ hashFiles('.submodule-hashes') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build Plugin
         run: mvn install -pl '!e2e' -DskipTests -B

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,17 @@ jobs:
             external/.deps-installed
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ hashFiles('.submodule-hashes') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Delete stale deps flag if submodules changed
+        shell: bash
+        run: |
+          if [ -f external/.deps-installed ]; then
+            current=$(git rev-parse HEAD:external/Boomerang HEAD:external/CryptoAnalysis HEAD:external/Crypto-API-Rules)
+            stored=$(cat external/.deps-installed)
+            if [ "$current" != "$stored" ]; then
+              rm external/.deps-installed
+              echo "Submodule commits changed; deleted external/.deps-installed to trigger reinstall."
+            fi
+          fi
       - name: Build & Test (No E2E) & Analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -87,6 +98,17 @@ jobs:
             external/.deps-installed
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ hashFiles('.submodule-hashes') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Delete stale deps flag if submodules changed
+        shell: bash
+        run: |
+          if [ -f external/.deps-installed ]; then
+            current=$(git rev-parse HEAD:external/Boomerang HEAD:external/CryptoAnalysis HEAD:external/Crypto-API-Rules)
+            stored=$(cat external/.deps-installed)
+            if [ "$current" != "$stored" ]; then
+              rm external/.deps-installed
+              echo "Submodule commits changed; deleted external/.deps-installed to trigger reinstall."
+            fi
+          fi
       - name: Build & Test (No E2E) & Analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -119,6 +141,17 @@ jobs:
             external/.deps-installed
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ hashFiles('.submodule-hashes') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Delete stale deps flag if submodules changed
+        shell: bash
+        run: |
+          if [ -f external/.deps-installed ]; then
+            current=$(git rev-parse HEAD:external/Boomerang HEAD:external/CryptoAnalysis HEAD:external/Crypto-API-Rules)
+            stored=$(cat external/.deps-installed)
+            if [ "$current" != "$stored" ]; then
+              rm external/.deps-installed
+              echo "Submodule commits changed; deleted external/.deps-installed to trigger reinstall."
+            fi
+          fi
       - name: Build Plugin
         run: mvn install -pl '!e2e' -DskipTests -B
       - name: E2E Tests

--- a/.gitignore
+++ b/.gitignore
@@ -71,8 +71,10 @@ claude-*.txt
 .sonar-code-context
 
 # Sentinel file written after external git-submodule deps are installed to ~/.m2.
-# Delete this file (or run: git clean -X external/) to force a rebuild.
+# Contains the submodule commit hashes at install time; delete to force a rebuild.
 external/.deps-installed
+external/.deps-installed.tmp
+.submodule-hashes
 
 # Extracted CrySL rules
 /utils/cognicrypt/src/main/resources/crysl_rules/*

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,72 @@
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <touch file="${project.basedir}/external/.deps-installed"/>
+                                        <exec executable="git"
+                                              output="${project.basedir}/external/.deps-installed"
+                                              failonerror="true">
+                                            <arg value="rev-parse"/>
+                                            <arg value="HEAD:external/Boomerang"/>
+                                            <arg value="HEAD:external/CryptoAnalysis"/>
+                                            <arg value="HEAD:external/Crypto-API-Rules"/>
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!--
+                Validates that the submodule commits recorded in external/.deps-installed
+                match the currently checked-out submodule pointers. If they differ (e.g.
+                after git submodule update), the stale flag file is deleted and the build
+                fails with a clear message. Re-run Maven once to trigger
+                install-external-deps and write fresh hashes.
+            -->
+            <id>check-external-deps-freshness</id>
+            <activation>
+                <file>
+                    <exists>external/.deps-installed</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>check-submodule-freshness</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target xmlns:if="ant:if">
+                                        <exec executable="git"
+                                              output="${project.basedir}/external/.deps-installed.tmp"
+                                              failonerror="true">
+                                            <arg value="rev-parse"/>
+                                            <arg value="HEAD:external/Boomerang"/>
+                                            <arg value="HEAD:external/CryptoAnalysis"/>
+                                            <arg value="HEAD:external/Crypto-API-Rules"/>
+                                        </exec>
+                                        <condition property="hashes.stale">
+                                            <not>
+                                                <filesmatch
+                                                    file1="${project.basedir}/external/.deps-installed"
+                                                    file2="${project.basedir}/external/.deps-installed.tmp"
+                                                    textfile="true"/>
+                                            </not>
+                                        </condition>
+                                        <delete file="${project.basedir}/external/.deps-installed.tmp"/>
+                                        <delete file="${project.basedir}/external/.deps-installed" if:set="hashes.stale"/>
+                                        <fail if:set="hashes.stale"
+                                              message="Submodule commits changed; external/.deps-installed deleted. Re-run Maven to reinstall external dependencies."/>
                                     </target>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
## Problem

`external/.deps-installed` was an empty sentinel file. After a `git submodule update`
the file remained present, so `install-external-deps` never re-ran. Developers had
to remember to manually delete it.

## Changes

**`pom.xml`**
- `mark-external-deps-installed` now writes the three submodule commit SHA1s into
  `.deps-installed` using `git rev-parse HEAD:external/Boomerang HEAD:external/CryptoAnalysis
  HEAD:external/Crypto-API-Rules`, instead of just touching an empty file.
- New `check-external-deps-freshness` profile activates whenever `.deps-installed` exists
  (the opposite condition from `install-external-deps`). In the `validate` phase it runs the
  same `git rev-parse`, compares output to the stored file using Ant's `<filesmatch
  textfile="true">` (line-ending-agnostic, cross-platform), and if the hashes differ: deletes
  the stale flag and fails with a clear message. Re-running Maven then triggers a fresh install.

**`.github/workflows/build.yml`**
- Adds a `git submodule status --cached > .submodule-hashes` step before each Maven cache
  action in `build-linux`, `build-windows`, and `e2e-test`.
- Includes `hashFiles('.submodule-hashes')` in the cache key so the cache is automatically
  invalidated when submodule pointers change, preventing a stale `.deps-installed` from ever
  being restored from cache.

**`.gitignore`** — adds `external/.deps-installed.tmp` and `.submodule-hashes`.

## Local verification

Three scenarios tested with `mvn validate -N -B`:

| Scenario | Expected | Result |
|---|---|---|
| `.deps-installed` is empty (pre-change state) | Stale detected → file deleted → BUILD FAILURE with message | ✅ |
| `.deps-installed` has old/wrong hashes (post-`git submodule update`) | Stale detected → file deleted → BUILD FAILURE with message | ✅ |
| `.deps-installed` has correct hashes | Freshness check passes → BUILD SUCCESS | ✅ |

The failure message in stale cases:
[INFO]    [delete] Deleting: .../external/.deps-installed.tmp
[INFO]    [delete] Deleting: .../external/.deps-installed
[INFO] BUILD FAILURE
[ERROR] Submodule commits changed; external/.deps-installed deleted.
        Re-run Maven to reinstall external dependencies.